### PR TITLE
Do not remove build directory on failure

### DIFF
--- a/autocmake/configure.py
+++ b/autocmake/configure.py
@@ -57,7 +57,6 @@ def run_cmake(command, build_path, default_build_path):
     Execute CMake command.
     """
     from subprocess import Popen, PIPE
-    from shutil import rmtree
 
     topdir = os.getcwd()
     p = Popen(command, shell=True, stdin=PIPE, stdout=PIPE, stderr=PIPE)
@@ -91,11 +90,6 @@ def run_cmake(command, build_path, default_build_path):
     if configuration_successful:
         save_setup_command(sys.argv, build_path)
         print_build_help(build_path, default_build_path)
-    else:
-        if (build_path == default_build_path):
-            # remove build_path iff not set by the user
-            # otherwise removal can be dangerous
-            rmtree(default_build_path)
 
 
 def print_build_help(build_path, default_build_path):


### PR DESCRIPTION
**Problem** For unsuccessful configurations, the default build directory is wiped away. This is inconsistent with the behavior obtained by calling bare CMake. It also prevents the user from looking at the logs to figure out what went wrong.
**Solution** Never remove the build directory.