### PR TITLE
Minor update of math_libs.cmake

### DIFF
--- a/modules/math_libs.cmake
+++ b/modules/math_libs.cmake
@@ -479,7 +479,7 @@ foreach(_service BLAS LAPACK)
 endforeach()
 
 # allow setting -mkl flags only if a one compiler (Fortran/C/C++) is Intel
-if(MKL_FLAG AND NOT MKL_FLAG STREQUAL "off" AND (CMAKE_Fortran_COMPILER_ID MATCHES Intel OR CMAKE_C_COMPILER_ID MATCHES C OR CMAKE_CXX_COMPILER_ID MATCHES Intel))
+if(MKL_FLAG AND NOT MKL_FLAG STREQUAL "off" AND (CMAKE_Fortran_COMPILER_ID MATCHES Intel OR CMAKE_C_COMPILER_ID MATCHES Intel OR CMAKE_CXX_COMPILER_ID MATCHES Intel))
     set(EXTERNAL_LIBS ${EXTERNAL_LIBS} -mkl=${MKL_FLAG})
     set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -mkl=${MKL_FLAG}")
     message(STATUS "User set explicit MKL flag which is passed to the compiler and linker: -mkl=${MKL_FLAG}")

--- a/modules/math_libs.cmake
+++ b/modules/math_libs.cmake
@@ -478,7 +478,8 @@ foreach(_service BLAS LAPACK)
     endif()
 endforeach()
 
-if(MKL_FLAG AND NOT MKL_FLAG STREQUAL "off")
+# allow setting -mkl flags only if a one compiler (Fortran/C/C++) is Intel
+if(MKL_FLAG AND NOT MKL_FLAG STREQUAL "off" AND (CMAKE_Fortran_COMPILER_ID MATCHES Intel OR CMAKE_C_COMPILER_ID MATCHES C OR CMAKE_CXX_COMPILER_ID MATCHES Intel))
     set(EXTERNAL_LIBS ${EXTERNAL_LIBS} -mkl=${MKL_FLAG})
     set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -mkl=${MKL_FLAG}")
     message(STATUS "User set explicit MKL flag which is passed to the compiler and linker: -mkl=${MKL_FLAG}")


### PR DESCRIPTION
allow setting the **-mkl**  flag only if a one of used compilers (Fortran, C or C++) is Intel