### PR TITLE
preserve quotes in setup_command; closes #169

### DIFF
--- a/autocmake/generate.py
+++ b/autocmake/generate.py
@@ -150,7 +150,7 @@ def gen_setup(config, default_build_type, relative_path, setup_script_name):
     s.append("cmake_command = '{0} -H{1}'.format(gen_cmake_command(options, arguments), root_directory)")
     s.append("\n")
     s.append("# run cmake")
-    s.append("configure.configure(root_directory, build_path, cmake_command, arguments['--show'])")
+    s.append("configure.configure(root_directory, build_path, cmake_command, arguments)")
 
     return s
 


### PR DESCRIPTION
The problem is that `sys.argv` has been stripped of quotes by the shell but `docopt`'s `arguments` contains quotes.

So what we do is cycle through all `docopt` `arguments`: if they are also present in the joined `sys.argv` string and contain spaces, we add quotes to the strings we find.